### PR TITLE
Executor - improved error_msg() method

### DIFF
--- a/src/utils/exit_handler.c
+++ b/src/utils/exit_handler.c
@@ -8,8 +8,6 @@ void	crash_exit(void)
 
 void	error_msg(char **context, char *msg)
 {
-	ft_putstr_fd(APP_NAME, STDERR_FILENO);
-	ft_putstr_fd(": ", STDERR_FILENO);
 	while (context && *context)
 	{
 		ft_putstr_fd(*context, STDERR_FILENO);

--- a/src/utils/expand_words.c
+++ b/src/utils/expand_words.c
@@ -69,9 +69,7 @@ static t_word	*expand_words(t_word *words)
 	words = expand_vars(words);
 	if (*words->str == '~' && (
 			(words->str[1] == '/')
-			|| (!words->str[1] && (
-					!words->next
-					|| *words->next->str == '/'))))
+			|| (!words->str[1] && !words->next)))
 	{
 		home = get_var_value("HOME");
 		str = words->str;


### PR DESCRIPTION
- improved error_msg() method
- improved tilted expand

When using error_msg or error_exit methods, the context param should be given like :
``(char *[]){APP_NAME, "error", 0}``

in this case, the output will be :
``misnihell: error: msg``