### PR TITLE
Merged t_builtin and t_cmd tokens

### DIFF
--- a/libs/betterft/betterft.h
+++ b/libs/betterft/betterft.h
@@ -6,7 +6,7 @@
 /*   By: rude-jes <rude-jes@student.42lausanne.c    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/09 13:19:26 by rude-jes          #+#    #+#             */
-/*   Updated: 2024/04/17 15:16:16 by rude-jes         ###   ########.fr       */
+/*   Updated: 2024/04/19 00:46:55 by rude-jes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@
 # include <sys/wait.h>
 # include <stdio.h>
 # include <limits.h>
+# include <sys/stat.h>
 
 # ifndef PATH_MAX
 #  define PATH_MAX 4096

--- a/src/executor/exec_child.c
+++ b/src/executor/exec_child.c
@@ -1,25 +1,7 @@
 #include "executor.h"
-#include <sys/stat.h>
-
-static void	error_cmd(char *path)
-{
-	int			err;
-	struct stat	path_stat;
-
-	err = errno;
-	if (stat(path, &path_stat) == 0 && S_ISDIR(path_stat.st_mode))
-		error_exit((char *[]){APP_NAME, path, 0}, IS_DIR, 126);
-	else if (err == EACCES)
-		error_exit((char *[]){APP_NAME, path, 0}, strerror(err), 126);
-	else if (!ft_strchr(path, '/'))
-		error_exit((char *[]){path, 0}, COMMAND_NOT_FOUND, 127);
-	else
-		error_exit((char *[]){APP_NAME, path, 0}, strerror(err), 127);
-}
 
 static pid_t	cmd_child(t_executor *executor, t_cmd *cmd)
 {
-	int		err;
 	char	*path;
 	char	**argv;
 
@@ -35,36 +17,41 @@ static pid_t	cmd_child(t_executor *executor, t_cmd *cmd)
 		path = find_binary(path);
 		execve(path, argv, get_minishell()->envp());
 		error_cmd(path);
+		gfree(path);
+		ft_free_tab(argv);
 	}
 	return (cmd->pid);
 }
 
-static int	start_builtin(t_executor *executor, t_builtin *builtin)
+static int	start_builtin(t_executor *executor, t_cmd *builtin)
 {
 	int		status;
+	char	*cmd;
 	char	**argv;
 
 	status = 127;
+	cmd = parse_words(builtin->cmd);
 	argv = parse_words_arr(builtin->argv);
-	if (builtin->cmd == builtin_cd)
+	if (!ft_strcmp(cmd, "cd"))
 		status = cd(builtin->argc, argv);
-	else if (builtin->cmd == builtin_echo)
+	else if (!ft_strcmp(cmd, "echo"))
 		status = echo(builtin->argc, argv);
-	else if (builtin->cmd == builtin_export)
+	else if (!ft_strcmp(cmd, "export"))
 		status = export_ms(builtin->argc, argv);
-	else if (builtin->cmd == builtin_exit)
+	else if (!ft_strcmp(cmd, "exit"))
 	{
 		if (!executor->has_pipe)
 			printf("exit\n");
 		status = exit_ms(builtin->argc, argv);
 	}
-	else if (builtin->cmd == builtin_pwd)
+	else if (!ft_strcmp(cmd, "pwd"))
 		status = pwd(builtin->argc, argv);
+	gfree(cmd);
 	ft_free_tab(argv);
 	return (status);
 }
 
-static pid_t	builtin_child(t_executor *executor, t_builtin *builtin)
+static pid_t	builtin_child(t_executor *executor, t_cmd *builtin)
 {
 	int		fd_status;
 
@@ -92,28 +79,43 @@ static pid_t	builtin_child(t_executor *executor, t_builtin *builtin)
 	return (builtin->pid);
 }
 
+static bool	is_builtin(t_cmd *cmd)
+{
+	bool	output;
+	char	*cmd_str;
+
+	cmd_str = parse_words(cmd->cmd);
+	if (!ft_strcmp(cmd_str, "cd") || !ft_strcmp(cmd_str, "echo")
+		|| !ft_strcmp(cmd_str, "export") || !ft_strcmp(cmd_str, "exit")
+		|| !ft_strcmp(cmd_str, "pwd"))
+		output = true;
+	else
+		output = false;
+	gfree(cmd_str);
+	return (output);
+}
+
 pid_t	init_child(t_executor *executor, t_token *tokens)
 {
-	pid_t		*pid;
-	t_cmd		*cmd;
-	t_builtin	*builtin;
+	pid_t	*pid;
+	t_cmd	*cmd;
 
 	pid = 0;
-	if (tokens->type == token_cmd)
+	cmd = (t_cmd *)tokens->data;
+	if (is_builtin(cmd))
+	{
+		pid = &cmd->pid;
+		builtin_child(executor, cmd);
+		update_var(new_var("_",
+				parse_words(cmd->argv[cmd->argc - 1]), true, false));
+	}
+	else
 	{
 		cmd = (t_cmd *)tokens->data;
 		pid = &cmd->pid;
 		cmd_child(executor, cmd);
 		update_var(new_var("_",
 				parse_words(cmd->argv[cmd->argc - 1]), true, false));
-	}
-	else if (tokens->type == token_builtin)
-	{
-		builtin = (t_builtin *)tokens->data;
-		pid = &builtin->pid;
-		builtin_child(executor, builtin);
-		update_var(new_var("_",
-				parse_words(builtin->argv[builtin->argc - 1]), true, false));
 	}
 	if (*pid < 0)
 		crash_exit();

--- a/src/executor/exec_pipe.c
+++ b/src/executor/exec_pipe.c
@@ -9,6 +9,33 @@ static int	init_pipe(t_executor *executor, t_pipe *pipes)
 	return (0);
 }
 
+int	dup_fd(t_executor *executor)
+{
+	if (executor->fd_in != STDIN_FILENO && executor->fd_in >= 0)
+	{
+		dup2(executor->fd_in, STDIN_FILENO);
+		close(executor->fd_in);
+	}
+	if (executor->fd_out != STDOUT_FILENO && executor->fd_out >= 0)
+	{
+		dup2(executor->fd_out, STDOUT_FILENO);
+		close(executor->fd_out);
+	}
+	if (executor->fd_in < 0)
+	{
+		error_msg((char *[]){APP_NAME,
+			executor->fd_in_path, 0}, strerror(errno));
+		return (-1);
+	}
+	if (executor->fd_out < 0)
+	{
+		error_msg((char *[]){APP_NAME,
+			executor->fd_out_path, 0}, strerror(errno));
+		return (-1);
+	}
+	return (0);
+}
+
 void	switch_fd(t_executor *executor, t_pipe *pipe)
 {
 	if (executor->fd_in_pipe)

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -28,18 +28,13 @@ static int	wait_tokens(t_executor *executor)
 	{
 		if (tokens->type == token_cmd)
 		{
-			waitpid(((t_cmd *)tokens->data)->pid, &status, 0);
-			status = get_wexistatus(status);
-		}
-		else if (tokens->type == token_builtin)
-		{
-			if (((t_builtin *)tokens->data)->pid)
+			if (((t_cmd *)tokens->data)->pid)
 			{
-				waitpid(((t_builtin *)tokens->data)->pid, &status, 0);
+				waitpid(((t_cmd *)tokens->data)->pid, &status, 0);
 				status = get_wexistatus(status);
 			}
 			else
-				status = ((t_builtin *)tokens->data)->status;
+				status = ((t_cmd *)tokens->data)->status;
 		}
 		tokens = tokens->next;
 	}
@@ -66,7 +61,7 @@ static void	execute_token(t_executor *executor, t_token **tokens)
 		exec_redir(executor, (*tokens));
 		return ;
 	}
-	else if ((*tokens)->type == token_cmd || (*tokens)->type == token_builtin)
+	else if ((*tokens)->type == token_cmd)
 	{
 		init_child(executor, (*tokens));
 		if (executor->fd_in != STDIN_FILENO)

--- a/src/executor/executor.h
+++ b/src/executor/executor.h
@@ -7,12 +7,6 @@
 # include "../utils/binary_finder.h"
 # include "../prompter/here_doc.h"
 
-//	Macros
-
-//		Error messages
-# define IS_DIR "is a directory"
-# define COMMAND_NOT_FOUND "command not found"
-
 typedef struct s_executor
 {
 	bool	has_pipe;

--- a/src/executor/executor.h
+++ b/src/executor/executor.h
@@ -10,7 +10,8 @@
 //	Macros
 
 //		Error messages
-# define NO_SUCH_FILE_OR_DIR "no such file or directory"
+# define IS_DIR "is a directory"
+# define COMMAND_NOT_FOUND "command not found"
 
 typedef struct s_executor
 {
@@ -39,5 +40,7 @@ int		get_wexistatus(int status);
 bool	has_pipe(t_token *tokens);
 //	switch_fd:	switch file descriptors
 void	switch_fd(t_executor *executor, t_pipe *pipe);
+//	dup_fd:	duplicate file descriptors
+int		dup_fd(t_executor *executor);
 
 #endif

--- a/src/main_shitty_tokenizer.c
+++ b/src/main_shitty_tokenizer.c
@@ -31,7 +31,7 @@ static void	print_lex(t_tlex *lex)
 
 static t_token	*shitty_quick_tokenizer(t_tlex *lexer)
 {
-	t_token *head;
+	t_token	*head;
 	t_token	*tmp;
 	t_token	*tokens;
 	int	i;
@@ -46,82 +46,26 @@ static t_token	*shitty_quick_tokenizer(t_tlex *lexer)
 			tmp = tokens;
 			tokens = tokens->next;
 		}
-		if (ft_strcmp(lexer->cmd->str, "|") && (!tmp || (tmp->type != token_cmd && tmp->type != token_builtin)))
+		if (ft_strcmp(lexer->cmd->str, "|") && (!tmp || tmp->type != token_cmd))
 		{
+			printf("NOON\n");
 			tokens = galloc(sizeof(t_token));
 			if (tmp)
 				tmp->next = tokens;
 			if (i == 0)
 				head = tokens;
-			if (!ft_strcmp (lexer->cmd->str, "cd"))
-			{
-				tokens->type = token_builtin;
-				tokens->data = ft_calloc(1, sizeof(t_builtin));
-				((t_builtin *)tokens->data)->cmd = builtin_cd;
-				((t_builtin *)tokens->data)->argv = ft_calloc(2, sizeof(t_word *));
-				((t_builtin *)tokens->data)->argv[0] = lexer->cmd;
-				((t_builtin *)tokens->data)->argv[1] = 0;
-				((t_builtin *)tokens->data)->argc = 1;
-			}
-			else if (!ft_strcmp(lexer->cmd->str, "echo"))
-			{
-				tokens->type = token_builtin;
-				tokens->data = ft_calloc(1, sizeof(t_builtin));
-				((t_builtin *)tokens->data)->cmd = builtin_echo;
-				((t_builtin *)tokens->data)->argv = ft_calloc(2, sizeof(t_word *));
-				((t_builtin *)tokens->data)->argv[0] = lexer->cmd;
-				((t_builtin *)tokens->data)->argv[1] = 0;
-				((t_builtin *)tokens->data)->argc = 1;
-			}
-			else if (!ft_strcmp(lexer->cmd->str, "exit"))
-			{
-				tokens->type = token_builtin;
-				tokens->data = ft_calloc(1, sizeof(t_builtin));
-				((t_builtin *)tokens->data)->cmd = builtin_exit;
-				((t_builtin *)tokens->data)->argv = ft_calloc(2, sizeof(t_word *));
-				((t_builtin *)tokens->data)->argv[0] = lexer->cmd;
-				((t_builtin *)tokens->data)->argv[1] = 0;
-				((t_builtin *)tokens->data)->argc = 1;
-			}
-			else if (!ft_strcmp(lexer->cmd->str, "export"))
-			{
-				tokens->type = token_builtin;
-				tokens->data = ft_calloc(1, sizeof(t_builtin));
-				((t_builtin *)tokens->data)->cmd = builtin_export;
-				((t_builtin *)tokens->data)->argv = ft_calloc(2, sizeof(t_word *));
-				((t_builtin *)tokens->data)->argv[0] = lexer->cmd;
-				((t_builtin *)tokens->data)->argv[1] = 0;
-				((t_builtin *)tokens->data)->argc = 1;
-			}
-			else if (!ft_strcmp(lexer->cmd->str, "pwd"))
-			{
-				tokens->type = token_builtin;
-				tokens->data = ft_calloc(1, sizeof(t_builtin));
-				((t_builtin *)tokens->data)->cmd = builtin_pwd;
-				((t_builtin *)tokens->data)->argv = ft_calloc(2, sizeof(t_word *));
-				((t_builtin *)tokens->data)->argv[0] = lexer->cmd;
-				((t_builtin *)tokens->data)->argv[1] = 0;
-				((t_builtin *)tokens->data)->argc = 1;
-			}
-			else
-			{
-				tokens->type = token_cmd;
-				tokens->data = ft_calloc(1, sizeof(t_cmd));
-				((t_cmd *)tokens->data)->cmd = lexer->cmd;
-				((t_cmd *)tokens->data)->argv = ft_calloc(2, sizeof(t_word *));
-				((t_cmd *)tokens->data)->argv[0] = lexer->cmd;
-				((t_cmd *)tokens->data)->argv[1] = 0;
-				((t_cmd *)tokens->data)->argc = 1;
-			}
-			if (!tmp)
-				tokens->prev = 0;
-			else
-				tokens->prev = tmp;
+			tokens->type = token_cmd;
+			tokens->data = ft_calloc(1, sizeof(t_cmd));
+			((t_cmd *)tokens->data)->cmd = lexer->cmd;
+			((t_cmd *)tokens->data)->argv = ft_calloc(2, sizeof(t_word *));
+			((t_cmd *)tokens->data)->argv[0] = lexer->cmd;
+			((t_cmd *)tokens->data)->argv[1] = 0;
+			((t_cmd *)tokens->data)->argc = 1;
 			tokens->next = 0;
 			lexer = lexer->next;
 			continue ;
 		}
-		else if (ft_strcmp(lexer->cmd->str, "|") && tmp && (tmp->type == token_cmd || tmp->type == token_builtin))
+		else if (ft_strcmp(lexer->cmd->str, "|") && tmp && tmp->type == token_cmd)
 		{
 			if (tmp->type == token_cmd)
 			{
@@ -130,13 +74,6 @@ static t_token	*shitty_quick_tokenizer(t_tlex *lexer)
 				((t_cmd *)tmp->data)->argv[((t_cmd *)tmp->data)->argc + 1] = 0;
 				((t_cmd *)tmp->data)->argc++;
 			}
-			else if (tmp->type == token_builtin)
-			{
-				((t_builtin *)tmp->data)->argv = ft_reallocf(((t_builtin *)tmp->data)->argv, (((t_builtin *)tmp->data)->argc) * sizeof(t_word *), (((t_builtin *)tmp->data)->argc + 2) * sizeof(t_word *));
-				((t_builtin *)tmp->data)->argv[((t_builtin *)tmp->data)->argc] = lexer->cmd;
-				((t_builtin *)tmp->data)->argv[((t_builtin *)tmp->data)->argc + 1] = 0;
-				((t_builtin *)tmp->data)->argc++;
-			}
 		}
 		else if (!ft_strcmp(lexer->cmd->str, "|"))
 		{
@@ -144,7 +81,6 @@ static t_token	*shitty_quick_tokenizer(t_tlex *lexer)
 			tmp->next = tokens;
 			tokens->type = token_pipe;
 			tokens->data = ft_calloc(1, sizeof(t_pipe));
-			tokens->prev = tmp;
 			tokens->next = 0;
 		}
 		lexer = lexer->next;
@@ -154,19 +90,45 @@ static t_token	*shitty_quick_tokenizer(t_tlex *lexer)
 
 static void	print_tokens(t_token *tokens)
 {
+	char	*token_type;
+
 	while (tokens)
 	{
-		printf("token n°%p\n", tokens);
-		printf("type: %d\n", tokens->type);
-		printf("prev: %p\n", tokens->prev);
+		printf("\ntoken %p\n", tokens);
+		if (tokens->type == token_cmd)
+			token_type = "token_cmd";
+		else if (tokens->type == token_var)
+			token_type = "token_var";
+		else if (tokens->type == token_pipe)
+			token_type = "token_pipe";
+		else if (tokens->type == token_stdin)
+			token_type = "token_stdin";
+		else if (tokens->type == token_stdout)
+			token_type = "token_stdout";
+		else if (tokens->type == token_and)
+			token_type = "token_and";
+		else if (tokens->type == token_or)
+			token_type = "token_or";
+		else if (tokens->type == token_grp)
+			token_type = "token_grp";
+		printf("type: %s\n", token_type);
 		printf("next: %p\n", tokens->next);
 		if (tokens->type == token_cmd)
 		{
-			printf("cmd: %s\n", ((t_cmd *)tokens->data)->cmd->str);
-			for (int i = 0; ((t_cmd *)tokens->data)->argv[i]; i++)
-				printf("argv[%d]: %s\n", i, ((t_cmd *)tokens->data)->argv[i]->str);
+			t_cmd	*cmd = (t_cmd *)tokens->data;
+			printf("cmd: ");
+			t_word	*tmp = cmd->cmd;
+			while (tmp)
+			{
+				printf("%s", tmp->str);
+				tmp = tmp->next;
+			}
+			printf("\n");
+			printf("argv: ");
+			for (int i = 0; cmd->argv[i]; i++)
+				printf("\"%s\", ", cmd->argv[i]->str);
 		}
-		printf("\n\n");
+		printf("\n");
 		tokens = tokens->next;
 	}
 }

--- a/src/main_shitty_tokenizer.c
+++ b/src/main_shitty_tokenizer.c
@@ -48,7 +48,6 @@ static t_token	*shitty_quick_tokenizer(t_tlex *lexer)
 		}
 		if (ft_strcmp(lexer->cmd->str, "|") && (!tmp || tmp->type != token_cmd))
 		{
-			printf("NOON\n");
 			tokens = galloc(sizeof(t_token));
 			if (tmp)
 				tmp->next = tokens;

--- a/src/minishell.h
+++ b/src/minishell.h
@@ -19,7 +19,6 @@ typedef struct s_word
 typedef enum e_token_type
 {
 	token_cmd,
-	token_builtin,
 	token_var,
 	token_pipe,
 	token_stdin,
@@ -29,23 +28,11 @@ typedef enum e_token_type
 	token_grp
 }				t_token_type;
 
-typedef enum e_builtin_type
-{
-	builtin_echo,
-	builtin_cd,
-	builtin_pwd,
-	builtin_export,
-	builtin_unset,
-	builtin_env,
-	builtin_exit
-}				t_builtin_type;
-
 //	Token structure
 typedef struct s_token
 {
 	void			*data;
 	t_token_type	type;
-	struct s_token	*prev;
 	struct s_token	*next;
 }				t_token;
 
@@ -55,17 +42,9 @@ typedef struct s_cmd
 	t_word	*cmd;
 	t_word	**argv;
 	int		argc;
+	int		status;
 	pid_t	pid;
 }				t_cmd;
-
-typedef struct s_builtin
-{
-	t_builtin_type	cmd;
-	t_word			**argv;
-	int				argc;
-	pid_t			pid;
-	int				status;
-}				t_builtin;
 
 typedef struct s_stdout
 {

--- a/src/utils/binary_finder.c
+++ b/src/utils/binary_finder.c
@@ -52,6 +52,8 @@ char	*find_binary(char *binary)
 			if (!output)
 				crash_exit();
 		}
+		else
+			return (binary);
 	}
 	else
 		output = get_fulpath(binary);

--- a/src/utils/exit_handler.c
+++ b/src/utils/exit_handler.c
@@ -28,3 +28,19 @@ void	error_exit(char **context, char *msg, int exitcode)
 	error_msg(context, msg);
 	exit(exitcode);
 }
+
+void	error_cmd(char *path)
+{
+	int			err;
+	struct stat	path_stat;
+
+	err = errno;
+	if (stat(path, &path_stat) == 0 && S_ISDIR(path_stat.st_mode))
+		error_exit((char *[]){APP_NAME, path, 0}, IS_DIR, 126);
+	else if (err == EACCES)
+		error_exit((char *[]){APP_NAME, path, 0}, strerror(err), 126);
+	else if (!ft_strchr(path, '/'))
+		error_exit((char *[]){path, 0}, COMMAND_NOT_FOUND, 127);
+	else
+		error_exit((char *[]){APP_NAME, path, 0}, strerror(err), 127);
+}

--- a/src/utils/exit_handler.h
+++ b/src/utils/exit_handler.h
@@ -4,11 +4,18 @@
 # include "../minishell.h"
 # include "../utils/colors.h"
 
+//	Error codes
+//		Error messages
+# define IS_DIR "is a directory"
+# define COMMAND_NOT_FOUND "command not found"
+
 //	crash_exit: exit the program when unexpected error
 void	crash_exit(void);
 //	error_exit: exit the program when expected error with specific message
 void	error_exit(char **context, char *msg, int exitcode);
 //	error_msg: sends specific error to the terminal without exiting
 void	error_msg(char **context, char *msg);
+//	error_cmd: sends specific error to the terminal and exits
+void	error_cmd(char *path);
 
 #endif


### PR DESCRIPTION
Having `t_builtin` and `t_cmd` tokens was redundant. We have decided to merge them into `t_cmd` directly. This change makes parsing lighter and permits handling builtin commands inside vars.