### PR TITLE
Refactor file descriptor handling and pipe initialization

### DIFF
--- a/src/executor/exec_redir.c
+++ b/src/executor/exec_redir.c
@@ -1,52 +1,57 @@
 #include "executor.h"
 
-static int	stdin_redir(t_executor *executor, t_stdin *stdin)
+static int	stdin_redir(t_context *context, t_stdin *stdin)
 {
 	int	fd;
 
-	if (executor->fd_in != STDIN_FILENO)
-		close(executor->fd_in);
+	if (context->fd_in != STDIN_FILENO)
+		close(context->fd_in);
 	if (!stdin->is_heredoc)
 	{
 		fd = open(stdin->filename, O_RDONLY);
-		executor->fd_in = fd;
-		executor->fd_in_path = stdin->filename;
+		context->fd_in = fd;
+		context->fd_in_path = stdin->filename;
 	}
 	else
 	{
 		fd = here_doc(stdin->limiter);
 		if (fd < 0)
 			return (fd);
-		executor->fd_in = fd;
+		context->fd_in = fd;
 	}
 	return (fd);
 }
 
-static int	stdout_redir(t_executor *executor, t_stdout *stdout)
+static int	stdout_redir(t_context *context, t_stdout *stdout)
 {
 	int	fd;
 
-	if (executor->fd_out != STDOUT_FILENO)
-		close(executor->fd_out);
+	if (context->fd_out != STDOUT_FILENO)
+		close(context->fd_out);
 	if (stdout->is_append)
 		fd = open(stdout->filename, O_WRONLY | O_CREAT | O_APPEND, 0644);
 	else
 		fd = open(stdout->filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
 	if (fd < 0)
 		return (fd);
-	executor->fd_out = fd;
-	executor->fd_out_path = stdout->filename;
+	context->fd_out = fd;
+	context->fd_out_path = stdout->filename;
 	return (fd);
 }
 
 void	exec_redir(t_executor *executor, t_token *tokens)
 {
-	while (tokens && tokens->type != token_pipe)
+	t_context	*context;
+
+	context = executor->context;
+	while (tokens && context)
 	{
 		if (tokens->type == token_stdin)
-			executor->fd_in = stdin_redir(executor, (t_stdin *)tokens->data);
+			context->fd_in = stdin_redir(context, (t_stdin *)tokens->data);
 		else if (tokens->type == token_stdout)
-			executor->fd_out = stdout_redir(executor, (t_stdout *)tokens->data);
+			context->fd_out = stdout_redir(context, (t_stdout *)tokens->data);
+		else if (tokens->type == token_pipe)
+			context = context->next;
 		tokens = tokens->next;
 	}
 }

--- a/src/executor/exec_signint.c
+++ b/src/executor/exec_signint.c
@@ -2,9 +2,11 @@
 
 void	exit_signint(t_executor *executor)
 {
-	t_token	*tokens;
+	t_token		*tokens;
+	t_context	*context;
 
 	tokens = executor->tokens;
+	context = executor->context;
 	while (tokens)
 	{
 		if (tokens->type == token_cmd)
@@ -14,10 +16,12 @@ void	exit_signint(t_executor *executor)
 		}
 		tokens = tokens->next;
 	}
-	if (executor->fd_in != STDIN_FILENO)
-		close(executor->fd_in);
-	if (executor->fd_out != STDOUT_FILENO)
-		close(executor->fd_out);
-	if (executor->fd_in_pipe)
-		close(executor->fd_in_pipe);
+	while (context)
+	{
+		if (context->fd_in != STDIN_FILENO && context->fd_in > -1)
+			close(context->fd_in);
+		if (context->fd_out != STDOUT_FILENO && context->fd_out > -1)
+			close(context->fd_out);
+		context = context->next;
+	}
 }

--- a/src/executor/exec_wexitstatus.c
+++ b/src/executor/exec_wexitstatus.c
@@ -1,10 +1,34 @@
 #include "executor.h"
 
-int	get_wexistatus(int status)
+static int	get_wexistatus(int status)
 {
 	if (WIFEXITED(status))
 		status = WEXITSTATUS(status);
 	else
 		status = 0;
+	return (status);
+}
+
+int	wait_tokens(t_executor *executor)
+{
+	t_token	*tokens;
+	int		status;
+
+	tokens = executor->tokens;
+	status = 0;
+	while (tokens)
+	{
+		if (tokens->type == token_cmd)
+		{
+			if (((t_cmd *)tokens->data)->pid)
+			{
+				waitpid(((t_cmd *)tokens->data)->pid, &status, 0);
+				status = get_wexistatus(status);
+			}
+			else
+				status = ((t_cmd *)tokens->data)->status;
+		}
+		tokens = tokens->next;
+	}
 	return (status);
 }

--- a/src/executor/executor.h
+++ b/src/executor/executor.h
@@ -7,35 +7,45 @@
 # include "../utils/binary_finder.h"
 # include "../prompter/here_doc.h"
 
+typedef struct s_context	t_context;
+typedef struct s_context
+{
+	t_context	*next;
+	bool		*has_pipe;
+	int			*og_fd_in;
+	int			*og_fd_out;
+	int			fd_in;
+	char		*fd_in_path;
+	int			fd_out;
+	char		*fd_out_path;
+}	t_context;
+
 typedef struct s_executor
 {
-	bool	has_pipe;
-	t_token	*tokens;
-	int		original_fd_in;
-	int		original_fd_out;
-	int		fd_in;
-	char	*fd_in_path;
-	int		fd_out;
-	char	*fd_out_path;
-	int		fd_in_pipe;
+	bool		has_pipe;
+	t_token		*tokens;
+	int			og_fd_in;
+	int			og_fd_out;
+	t_context	*context;
 }	t_executor;
 
 //	executor:	execute a list of tokens inside minishell
 void	executor(t_token *tokens);
 //	init_child:	init and execute a child from cmd or builtin token
-pid_t	init_child(t_executor *executor, t_token *tokens);
+pid_t	init_child(t_context *context, t_token *tokens);
 //	exec_pipe:	Handles pipe type tokens
 int		exec_pipe(t_executor *executor, t_token *tokens);
 //	exec_redir:	handles redirections type tokens
 void	exec_redir(t_executor *executor, t_token *tokens);
-//	get_wexistatus:	get the exit status from a waitpid status
-int		get_wexistatus(int status);
+//	wait_tokens:	wait for tokens to finish executing
+//	returns last process exit code
+int		wait_tokens(t_executor *executor);
 //	has_pipe:	check if a token list has a pipe token
 bool	has_pipe(t_token *tokens);
 //	switch_fd:	switch file descriptors
 void	switch_fd(t_executor *executor, t_pipe *pipe);
-//	dup_fd:	duplicate file descriptors
-int		dup_fd(t_executor *executor);
+//	dup_fd:	duplicate file descriptors to STDIN_FILENO and STDOUT_FILENO
+int		dup_fd(t_context *context);
 //	exit_signint:	exit all processes killing them with SIGINT
 void	exit_signint(t_executor *executor);
 


### PR DESCRIPTION
related issue :
- https://github.com/RPDJF/42-minishell/issues/47

Each pipe now has its own execution context, which resolves the issue of "Here documents being executed in the middle of the process when piped", rather than processing the file descriptors after each pipe