### PR TITLE
Experimental and or tokens execution (without parentheses)

### DIFF
--- a/src/env/env.c
+++ b/src/env/env.c
@@ -1,6 +1,33 @@
 #include "env.h"
 #include "../utils/binary_finder.h"
 
+static int	shlvl_parse(char *shlvl)
+{
+	int		shlvl_int;
+	char	*errmsg;
+	char	*tmp;
+
+	shlvl_int = ft_atoi(shlvl) + 1;
+	if (shlvl_int < 0)
+		shlvl_int = 0;
+	if (shlvl_int > 999)
+	{
+		errmsg = ft_itoa(shlvl_int);
+		if (!errmsg)
+			crash_exit();
+		tmp = errmsg;
+		errmsg = ft_strsjoin(3,
+				"shell level (", errmsg, ") too high, resetting to 1");
+		if (!errmsg)
+			crash_exit();
+		gfree(tmp);
+		error_msg((char *[]){APP_NAME, "warning", 0}, errmsg);
+		gfree(errmsg);
+		shlvl_int = 1;
+	}
+	return (shlvl_int);
+}
+
 static char	*parse_var(char *var_name)
 {
 	char	*env;
@@ -12,7 +39,7 @@ static char	*parse_var(char *var_name)
 		if (!env)
 			output = ft_strdup("1");
 		else
-			output = ft_itoa(ft_atoi(env) + 1);
+			output = ft_itoa(shlvl_parse(env));
 	}
 	else if (!ft_strcmp(var_name, "PWD"))
 		output = addgarbage(getcwd(0, 0));

--- a/src/executor/context.c
+++ b/src/executor/context.c
@@ -7,7 +7,8 @@ static size_t	count_context(t_token *tokens)
 	count = 1;
 	while (tokens)
 	{
-		if (tokens->type == token_pipe)
+		if (tokens->type == token_pipe
+			|| tokens->type == token_and || tokens->type == token_or)
 			count++;
 		tokens = tokens->next;
 	}
@@ -42,10 +43,9 @@ static void	init_fd_dup(t_executor *executor)
 	{
 		type = tokens->type;
 		if (type == token_pipe)
-		{
 			exec_pipe(context, tokens);
+		if (type == token_pipe || type == token_and || type == token_or)
 			context = context->next;
-		}
 		else if (type == token_stdin || type == token_stdout)
 			exec_redir(context, tokens);
 		tokens->context = context;

--- a/src/executor/context.c
+++ b/src/executor/context.c
@@ -7,8 +7,7 @@ static size_t	count_context(t_token *tokens)
 	count = 1;
 	while (tokens)
 	{
-		if (tokens->type == token_pipe
-			|| tokens->type == token_and || tokens->type == token_or)
+		if (tokens->type == token_pipe)
 			count++;
 		tokens = tokens->next;
 	}

--- a/src/executor/exec_utils.c
+++ b/src/executor/exec_utils.c
@@ -17,6 +17,24 @@ bool	is_builtin(t_cmd *cmd)
 	return (output);
 }
 
+t_token	*find_last_cmd(t_executor *exec, t_token *token)
+{
+	t_token	*cmd;
+	t_token	*p;
+
+	cmd = 0;
+	p = exec->tokens;
+	while (p != token && p)
+	{
+		if (p->type == token_cmd
+			&& (((t_cmd *)p->data)->pid
+				|| ((t_cmd *)p->data)->status))
+			cmd = p;
+		p = p->next;
+	}
+	return (cmd);
+}
+
 t_cmd	*find_cmd(t_cmd *cmd)
 {
 	char	*cmd_str;

--- a/src/executor/executor.h
+++ b/src/executor/executor.h
@@ -37,11 +37,11 @@ pid_t		init_child(t_token *tokens);
 void		exec_pipe(t_context *context, t_token *tokens);
 //	exec_redir:	handles redirections type tokens
 void		exec_redir(t_context *context, t_token *tokens);
-//	wait_tokens:	wait for tokens to finish executing
+//	wait_all_tokens:	wait for tokens to finish executing
 //	returns last process exit code
-int			wait_tokens(t_executor *executor);
-//	wait_last_token:	wait for the last token to finish executing
-int			wait_last_token(t_executor *executor, t_token *tokens);
+int			wait_all_tokens(t_executor *executor);
+//	wait_token:	wait for a token to finish executing
+int			wait_token(t_token *token);
 //	has_pipe:	check if a token list has a pipe token
 bool		has_pipe(t_token *tokens);
 //	switch_fd:	switch file descriptors
@@ -60,5 +60,7 @@ t_cmd		*find_cmd(t_cmd *cmd);
 void		close_all_fd(t_context *context);
 //	init_executor:	initialize executor struct
 t_context	*init_context(t_executor *executor);
+//	find_last_cmd:	find the last command in the executor
+t_token		*find_last_cmd(t_executor *exec, t_token *token);
 
 #endif

--- a/src/parsing/parsing_delem.c
+++ b/src/parsing/parsing_delem.c
@@ -51,13 +51,13 @@ int	tk_delem(t_token *neww, t_pars *pars)
 		}
 		else if (!ft_strcmp(pars->tmp1->cmd->str, "||"))
 		{
-			neww->type = token_and;
+			neww->type = token_or;
 			pars->tmp1 = pars->tmp1->next;
 			return (1);
 		}
 		else if (!ft_strcmp(pars->tmp1->cmd->str, "&&"))
 		{
-			neww->type = token_or;
+			neww->type = token_and;
 			pars->tmp1 = pars->tmp1->next;
 			return (1);
 		}


### PR DESCRIPTION
- Adds an experimental version of and and or tokens execution (without parentheses)
- Fix context count being too high 21dbeadf6943f9bcf484d7a24df2718c98348a05
- Fix shell level parsing in env 0fff7e6b19cad40f19cb73ffb55ad4f6efe770ae