### PR TITLE
fixe issue #90

### DIFF
--- a/src/parsing/pars_t_var_init.c
+++ b/src/parsing/pars_t_var_init.c
@@ -3,9 +3,12 @@
 
 int	correct_syntax_var(char *str)
 {
+	if (*str && (ft_isdigit(*str) || !ft_isalpha(*str)))
+		return (0);
+	str++;
 	while (*str && *str != '=')
 	{
-		if (!ft_isalpha(*str) && *str != '_')
+		if (!ft_isalnum(*str) && *str != '_')
 			return (0);
 		str++;
 	}


### PR DESCRIPTION
---
fixed :
- https://github.com/RPDJF/42-minishell/issues/90
---
new behavior :
```bash
┌─[ilkayyanar] [SHLVL 3]
└─[~/travail/repo_github/minishell-42] [0]-❥ a=mdr

┌─[ilkayyanar] [SHLVL 3]
└─[~/travail/repo_github/minishell-42] [0]-❥ 2a=mdr
minishell: 2a=mdr: command not found

┌─[ilkayyanar] [SHLVL 3]
└─[~/travail/repo_github/minishell-42] [127]-❥ 22323a=mdr
minishell: 22323a=mdr: command not found

┌─[ilkayyanar] [SHLVL 3]
└─[~/travail/repo_github/minishell-42] [127]-❥ $@22323a=mdr
minishell: $@22323a=mdr: command not found

┌─[ilkayyanar] [SHLVL 3]
└─[~/travail/repo_github/minishell-42] [127]-❥ a42424=mdr
```