### PR TITLE
Bug fixes and optimizations

### DIFF
--- a/src/executor/exec_subshell.c
+++ b/src/executor/exec_subshell.c
@@ -30,7 +30,7 @@ pid_t	init_subshell(t_token *tokens)
 	if (subshell->pid < 0)
 		crash_exit();
 	if (subshell->pid == 0)
-		exit(start_subshell(tokens));
+		secure_exit(start_subshell(tokens));
 	if (tokens->context->fd_in != STDIN_FILENO)
 		close(tokens->context->fd_in);
 	if (tokens->context->fd_out != STDOUT_FILENO)

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -83,5 +83,6 @@ t_tlex	*lexer(char *input)
 			if (words_lexing(&lex, input, &tlex) == 1)
 				return (free_exit_lexer(&tlex));
 	}
+	gfree(input);
 	return (tlex);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -15,17 +15,11 @@ int	main(int argc, char **argv, char **envp)
 		input = prompt(init_minishell(argc, argv, envp));
 		lex = lexer(input);
 		if (!lex)
-		{
-			gfree(input);
 			continue ;
-		}
 		token = parsing(&lex);
 		if (!token)
-		{
-			gfree(input);
 			continue ;
-		}
 		executor(token);
-		free_all(&token, &lex, &input);
+		free_all(&token, &lex);
 	}
 }

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -51,9 +51,10 @@ t_minishell	*init_minishell(int argc, char **argv, char **envp)
 	minishell->envp = &var_to_tab;
 	minishell->hostname = mini_gethostname();
 	minishell->is_interactive = true;
-	ms_load_history();
 	init_signals();
 	script_mode();
+	if (!minishell->is_script)
+		ms_load_history();
 	return (minishell);
 }
 

--- a/src/parsing/parsing.h
+++ b/src/parsing/parsing.h
@@ -85,6 +85,6 @@ void			*check_syntax_subshell(t_token *token);
 int				token_syntax(t_token *token);
 int				tk_delem_syntax(t_word *cmd, bool print);
 int				syntax_redirection(t_word *cmd, t_word *prev);
-void			free_all(t_token **token, t_tlex **lex, char **input);
+void			free_all(t_token **token, t_tlex **lex);
 
 #endif

--- a/src/prompter/prompt.c
+++ b/src/prompter/prompt.c
@@ -50,16 +50,12 @@ static char	*script_prompt(void)
 
 	while (true)
 	{
-		input = addgarbage(ft_get_next_line(STDIN_FILENO));
+		input = ft_get_next_line(STDIN_FILENO);
 		if (!input)
 			secure_exit(0);
 		trim = ft_strtrim(input, " \t\v\f\r\n");
 		if (*trim == '#' || !*trim)
-		{
-			gfree(input);
-			gfree(trim);
 			continue ;
-		}
 		return (input);
 	}
 }

--- a/src/utils/free_all.c
+++ b/src/utils/free_all.c
@@ -1,11 +1,10 @@
 #include "../parsing/parsing.h"
 
-void	free_all(t_token **token, t_tlex **lex, char **input)
+void	free_all(t_token **token, t_tlex **lex)
 {
 	t_tlex	*tmp1;
 	t_token	*tmp2;
 
-	gfree(*input);
 	while (*lex)
 	{
 		if ((*lex)->cmd)


### PR DESCRIPTION
- subshell now using secure_exit instead of exit 1a3ed72fbe6c40ea714de08275c76805e2b7b554
- input is now freed when not being necessary anymore 15a34d8060502aa2274eb60f6d91dae6a4f7dac3
- when minishell is on script_mode it no longer loads minishell_history fbce1cab7832d904d9cfcee29117cd6e7140c40d
- removed slow unnecessary code and fix double-free in script_prompt d1522848b0613c64e7c389577caaa31e22bd9c9b